### PR TITLE
Implement IP address validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ Method	Description	Example Usage
 | ValidateContainsUppercase   | Ensures a string contains at least one uppercase letter         | `vc.ValidateContainsUppercase(value, "FieldName", "Must contain an uppercase letter")` |
 | ValidateContainsLowercase   | Ensures a string contains at least one lowercase letter         | `vc.ValidateContainsLowercase(value, "FieldName", "Must contain a lowercase letter")` |
 | ValidateURL                 | Checks if a string is a valid URL                               | `vc.ValidateURL(value, "FieldName", "Invalid URL format")`              |
+| ValidateIPAddress           | Checks if a value is a valid IP address (IPv4 or IPv6) | `vc.ValidateIPAddress(value, "FieldName", "Invalid IP address")` |
+| ValidateIPv4                | Checks if a value is a valid IPv4 address        | `vc.ValidateIPv4(value, "FieldName", "Invalid IPv4 address")` |
+| ValidateIPv6                | Checks if a value is a valid IPv6 address        | `vc.ValidateIPv6(value, "FieldName", "Invalid IPv6 address")` |
 | ValidateFilePath            | Ensures the file path is valid                                  | `vc.ValidateFilePath(value, "FilePath", "Invalid file path")`           |
 | ValidateFileExtension       | Checks if a file has a valid extension                          | `vc.ValidateFileExtension(file, "FieldName", []string{".jpg", ".png"}, "")` |
 | ValidateFileSize            | Ensures the file size is within the specified limit             | `vc.ValidateFileSize(file, "FieldName", 2*1024*1024, "File size must be 2MB or less")` |

--- a/validate_network.go
+++ b/validate_network.go
@@ -1,0 +1,41 @@
+package validationcontext
+
+import (
+	"fmt"
+	"net"
+)
+
+// ValidateIPAddress checks if the value is a valid IP address (IPv4 or IPv6).
+func (vc *ValidationContext) ValidateIPAddress(value, field, errMsg string) {
+	if ip := net.ParseIP(value); ip == nil {
+		if errMsg != "" {
+			vc.AddError(field, errMsg)
+			return
+		}
+		vc.AddError(field, fmt.Sprintf("%sには、有効なIPアドレスを指定してください。", field))
+	}
+}
+
+// ValidateIPv4 checks if the value is a valid IPv4 address.
+func (vc *ValidationContext) ValidateIPv4(value, field, errMsg string) {
+	ip := net.ParseIP(value)
+	if ip == nil || ip.To4() == nil {
+		if errMsg != "" {
+			vc.AddError(field, errMsg)
+			return
+		}
+		vc.AddError(field, fmt.Sprintf("%sには、有効なIPv4アドレスを指定してください。", field))
+	}
+}
+
+// ValidateIPv6 checks if the value is a valid IPv6 address.
+func (vc *ValidationContext) ValidateIPv6(value, field, errMsg string) {
+	ip := net.ParseIP(value)
+	if ip == nil || ip.To4() != nil {
+		if errMsg != "" {
+			vc.AddError(field, errMsg)
+			return
+		}
+		vc.AddError(field, fmt.Sprintf("%sには、有効なIPv6アドレスを指定してください。", field))
+	}
+}

--- a/validationcontext_test.go
+++ b/validationcontext_test.go
@@ -515,6 +515,72 @@ func TestValidateURL(t *testing.T) {
 	}
 }
 
+func TestValidateIPAddress(t *testing.T) {
+	tests := []struct {
+		name           string
+		value          string
+		expectErrCount int
+	}{
+		{"ValidIPv4", "192.168.0.1", 0},
+		{"ValidIPv6", "2001:db8::1", 0},
+		{"InvalidIP", "not-an-ip", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vc := NewValidationContext()
+			vc.ValidateIPAddress(tt.value, "Field1", "")
+			if len(vc.Errors()) != tt.expectErrCount {
+				t.Errorf("Expected error count: %v, got: %v", tt.expectErrCount, len(vc.Errors()))
+			}
+		})
+	}
+}
+
+func TestValidateIPv4(t *testing.T) {
+	tests := []struct {
+		name           string
+		value          string
+		expectErrCount int
+	}{
+		{"ValidIPv4", "192.168.0.1", 0},
+		{"IPv6Value", "2001:db8::1", 1},
+		{"InvalidIP", "bad-ip", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vc := NewValidationContext()
+			vc.ValidateIPv4(tt.value, "Field1", "")
+			if len(vc.Errors()) != tt.expectErrCount {
+				t.Errorf("Expected error count: %v, got: %v", tt.expectErrCount, len(vc.Errors()))
+			}
+		})
+	}
+}
+
+func TestValidateIPv6(t *testing.T) {
+	tests := []struct {
+		name           string
+		value          string
+		expectErrCount int
+	}{
+		{"ValidIPv6", "2001:db8::1", 0},
+		{"IPv4Value", "192.168.0.1", 1},
+		{"InvalidIP", "bad-ip", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vc := NewValidationContext()
+			vc.ValidateIPv6(tt.value, "Field1", "")
+			if len(vc.Errors()) != tt.expectErrCount {
+				t.Errorf("Expected error count: %v, got: %v", tt.expectErrCount, len(vc.Errors()))
+			}
+		})
+	}
+}
+
 func TestValidateFile(t *testing.T) {
 	// テスト用の一時ファイルを作成
 	tmpFile, err := os.CreateTemp("", "testfile")


### PR DESCRIPTION
## Summary
- add `ValidateIPAddress`, `ValidateIPv4`, and `ValidateIPv6`
- cover new validators with tests
- document the new validators in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843a40179dc832e8adfb75d2dc51d65