### PR TITLE
Fix file validation errors

### DIFF
--- a/validate_file.go
+++ b/validate_file.go
@@ -9,13 +9,11 @@ import (
 // ValidateFilePath checks if the value is a valid file path.
 func (vc *ValidationContext) ValidateFilePath(value, field, errMsg string) {
 	if _, err := os.Stat(value); err != nil {
-		if os.IsNotExist(err) {
-			if errMsg != "" {
-				vc.AddError(field, errMsg)
-				return
-			}
-			vc.AddError(field, fmt.Sprintf("%sには、有効なファイルパスを指定してください。", field))
+		if errMsg != "" {
+			vc.AddError(field, errMsg)
+			return
 		}
+		vc.AddError(field, fmt.Sprintf("%sには、有効なファイルパスを指定してください。", field))
 	}
 }
 

--- a/validate_string.go
+++ b/validate_string.go
@@ -143,13 +143,11 @@ func (vc *ValidationContext) ValidateURL(value, field, errMsg string) {
 // ValidateFile checks if the value is a valid file path.
 func (vc *ValidationContext) ValidateFile(value, field, errMsg string) {
 	if _, err := os.Stat(value); err != nil {
-		if os.IsNotExist(err) {
-			if errMsg != "" {
-				vc.AddError(field, errMsg)
-				return
-			}
-			vc.AddError(field, fmt.Sprintf("%sには、有効なファイルパスを指定してください。", field))
+		if errMsg != "" {
+			vc.AddError(field, errMsg)
+			return
 		}
+		vc.AddError(field, fmt.Sprintf("%sには、有効なファイルパスを指定してください。", field))
 	}
 }
 

--- a/validationcontext_test.go
+++ b/validationcontext_test.go
@@ -535,7 +535,7 @@ func TestValidateFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			vc := NewValidationContext()
-			vc.ValidateFilePath(tt.value, "Field1", "")
+			vc.ValidateFile(tt.value, "Field1", "")
 			if len(vc.Errors()) != tt.expectErrCount {
 				t.Errorf("Expected error count: %v, got: %v", tt.expectErrCount, len(vc.Errors()))
 			}


### PR DESCRIPTION
## Summary
- handle any error in ValidateFilePath and ValidateFile
- call ValidateFile correctly in tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843a3de0f84832ea492801a37ea5d1d